### PR TITLE
allow ssh git clone url

### DIFF
--- a/erucli/console/cmdline.py
+++ b/erucli/console/cmdline.py
@@ -11,7 +11,7 @@ from erucli.console.commands import commands
 from erucli.console.style import error
 
 
-def create_http_git_clone_url(clone_url):
+def create_http_git_clone_url(clone_url, scheme='http'):
     """
     >>> create_http_git_clone_url('git@github.com:projecteru/eru-cli.git')
     'http://github.com/projecteru/eru-cli.git'
@@ -24,6 +24,19 @@ def create_http_git_clone_url(clone_url):
     return http_clone_url
 
 
+def create_ssh_git_clone_url(clone_url):
+    """
+    >>> create_ssh_git_clone_url('https://github.com/neovim/neovim.git')
+    'git@github.com:neovim/neovim.git'
+    """
+    if clone_url.startswith('git'):
+        return clone_url
+    parsed = urlparse.urlparse(clone_url, 'https')
+    netloc, path = parsed.netloc, parsed.path
+    ssh_clone_url = 'git@' + netloc + ':' + path.lstrip('/')
+    return ssh_clone_url
+
+
 def make_absolute_path(domain_name_or_url):
     """
     >>> make_absolute_path('127.0.0.1')
@@ -31,16 +44,17 @@ def make_absolute_path(domain_name_or_url):
     >>> make_absolute_path('http://127.0.0.1:10086/')
     'http://127.0.0.1:10086'
     """
-    p = urlparse.urlparse(domain_name_or_url, 'http')
-    netloc = p.netloc or p.path
-    p = urlparse.ParseResult('http', netloc, '', *p[3:])
-    return p.geturl()
+    parsed = urlparse.urlparse(domain_name_or_url, 'http')
+    netloc = parsed.netloc or parsed.path
+    parse_result = urlparse.ParseResult('http', netloc, '', *parsed[3:])
+    return parse_result.geturl()
 
 
 
 @click.group()
+@click.option('--clone-url-type', type=click.Choice(['http', 'https', 'ssh']), default='http')
 @click.pass_context
-def eru_commands(ctx):
+def eru_commands(ctx, clone_url_type):
     if not os.path.exists(os.path.abspath('./.git')):
         click.echo(error('Must run inside git dir'))
         ctx.exit(-1)
@@ -63,7 +77,10 @@ def eru_commands(ctx):
     ctx.obj['short_sha1'] = appconfig.get('version', '')[:7] or ctx.obj['sha1'][:7]
 
     origin_remote_url = next(r.url for r in repo.remotes if r.name == 'origin')
-    ctx.obj['remote']  = create_http_git_clone_url(origin_remote_url)
+    if clone_url_type.startswith('http'):
+        ctx.obj['remote']  = create_http_git_clone_url(origin_remote_url, clone_url_type)
+    else:
+        ctx.obj['remote']  = create_ssh_git_clone_url(origin_remote_url)
 
     eru_absolute_path = make_absolute_path(eru_url)
     ctx.obj['eru'] = EruClient(eru_absolute_path)


### PR DESCRIPTION
but the resulting oiption usage is weird: 
`eru-cli --clone-url-type ssh app:listcontainer`

把option放在前最前边是不是不太好啊，随便了 不会用click
